### PR TITLE
防止 1.20.5+ 新增的 BODY 槽位导致发包装备崩溃

### DIFF
--- a/project/common-impl/src/main/kotlin/ink/ptms/adyeshach/impl/entity/DefaultEquipable.kt
+++ b/project/common-impl/src/main/kotlin/ink/ptms/adyeshach/impl/entity/DefaultEquipable.kt
@@ -19,6 +19,14 @@ import org.bukkit.inventory.ItemStack
 @Suppress("SpellCheckingInspection")
 interface DefaultEquipable : EntityEquipable {
 
+    companion object {
+        val SUPPORTED_SLOTS = setOf(
+            EquipmentSlot.HAND, EquipmentSlot.OFF_HAND,
+            EquipmentSlot.FEET, EquipmentSlot.LEGS,
+            EquipmentSlot.CHEST, EquipmentSlot.HEAD,
+        )
+    }
+
     override fun clearEquipment() {
         this as DefaultEntityLiving
         equipment.clear()
@@ -29,7 +37,7 @@ interface DefaultEquipable : EntityEquipable {
         this as DefaultEntityLiving
         val operator = Adyeshach.api().getMinecraftAPI().getEntityOperator()
         val players = getVisiblePlayers()
-        val equipment = EquipmentSlot.values().associateWith { getEquipment(it) ?: ItemStack(Material.AIR) }.toMutableMap()
+        val equipment = SUPPORTED_SLOTS.associateWith { getEquipment(it) ?: ItemStack(Material.AIR) }.toMutableMap()
         AdyeshachEntityEquipmentUpdateEvent(players, this, equipment).call()
         operator.updateEquipment(players, index, equipment)
     }
@@ -37,7 +45,7 @@ interface DefaultEquipable : EntityEquipable {
     override fun updateEquipment(player: Player) {
         this as DefaultEntityLiving
         val operator = Adyeshach.api().getMinecraftAPI().getEntityOperator()
-        val equipment = EquipmentSlot.values().associateWith { getEquipment(it) ?: ItemStack(Material.AIR) }.toMutableMap()
+        val equipment = SUPPORTED_SLOTS.associateWith { getEquipment(it) ?: ItemStack(Material.AIR) }.toMutableMap()
         AdyeshachEntityEquipmentUpdateEvent(listOf(player), this, equipment).call()
         operator.updateEquipment(player, index, equipment)
     }


### PR DESCRIPTION
1.20.5+ Bukkit API 的 EquipmentSlot 枚举新增了 BODY 槽位。 在 DefaultEquipable.updateEquipment() 中，目前使用的是 EquipmentSlot.values() 遍历所有槽位。底层的 NMS 映射不包含对 BODY 的适配，遍历到该槽位时会抛出 IllegalStateException（已在个人更改版本1.21实测过，确有这个问题，但是对于1.20.4及以下暂时不会有什么问题）