### PR TITLE
feat: 新增 Settings.negative-entity-id 配置项，允许使用正数虚拟实体 ID

### DIFF
--- a/project/common-impl/src/main/kotlin/ink/ptms/adyeshach/impl/util/Indexs.kt
+++ b/project/common-impl/src/main/kotlin/ink/ptms/adyeshach/impl/util/Indexs.kt
@@ -1,5 +1,6 @@
 package ink.ptms.adyeshach.impl.util
 
+import ink.ptms.adyeshach.core.AdyeshachSettings
 import taboolib.common.util.random
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -10,7 +11,10 @@ import java.util.concurrent.atomic.AtomicInteger
 @Suppress("SpellCheckingInspection", "GrazieInspection")
 object Indexs {
 
-    var index = AtomicInteger(449599 + random(0, 702))
+    /**
+     * 是否使用负数虚拟实体 ID（取配置 Settings.negative-entity-id，初始化时缓存，修改后需重启生效）。
+     */
+    private val negative = AdyeshachSettings.negativeEntityId
 
     /**
      * int 最大值           2,147,483,647
@@ -18,9 +22,14 @@ object Indexs {
      * lib hologram          449,599,702
      * adyeshach npc             449,599 + (0~702)
      *
-     * 客户端只需要同一次会话内唯一的实体 ID，使用负数可以避开服务端真实实体 ID。
+     * 客户端只需要同一次会话内唯一的实体 ID。
+     * 默认使用负数可以避开服务端真实实体 ID；
+     * 若客户端 mod 无法处理负数实体 ID（如 DragonCore），可改用正数，
+     * 基数抬到 1_500_000_000 以尽量避免与服务端真实实体 ID 冲突。
      */
+    var index = AtomicInteger((if (negative) 449599 else 1_500_000_000) + random(0, 702))
+
     fun nextIndex(): Int {
-        return -index.getAndIncrement()
+        return if (negative) -index.getAndIncrement() else index.getAndIncrement()
     }
 }

--- a/project/common/src/main/kotlin/ink/ptms/adyeshach/core/AdyeshachSettings.kt
+++ b/project/common/src/main/kotlin/ink/ptms/adyeshach/core/AdyeshachSettings.kt
@@ -98,6 +98,14 @@ object AdyeshachSettings {
     var disableSave = false
 
     /**
+     * 是否使用负数虚拟实体 ID
+     * 负数可彻底避开与服务端真实实体 ID 的冲突，但部分客户端 mod（如 DragonCore）无法处理负数实体 ID，
+     * 此时可设为 false 改用正数 ID（基数自动抬到 15 亿，尽量避免与真实实体冲突）。
+     */
+    @ConfigNode("Settings.negative-entity-id")
+    var negativeEntityId = true
+
+    /**
      * 是否为自动删除世界
      */
     fun isAutoDeleteWorld(world: String): Boolean {

--- a/project/common/src/main/resources/core/config.yml
+++ b/project/common/src/main/resources/core/config.yml
@@ -31,3 +31,9 @@ Settings:
   # 是否禁用保存功能
   # 使用自定义保存策略时开启
   disable-save: false
+  # 是否使用负数虚拟实体 ID（默认 true）
+  # 负数 ID 可彻底避开与服务端真实实体 ID 的冲突。
+  # 但部分客户端 mod（如 DragonCore 龙核）无法处理负数实体 ID，
+  # 会导致这些 mod 无法在 Adyeshach 单位上渲染模型（只显示原始实体）。
+  # 遇到此类兼容问题可设为 false，改用正数 ID（基数自动抬到 15 亿，尽量避免与真实实体 ID 冲突）。
+  negative-entity-id: true


### PR DESCRIPTION
## 背景

关联 #119

`2.1.30`（commit `300420f5`）将 `impl/util/Indexs.kt` 的 `nextIndex()` 改为返回**负数**虚拟实体 ID，用于避开服务端真实实体 ID / 全息撞 ID。

但部分客户端 mod（如 **DragonCore** 龙核）无法处理**负数实体 ID**，导致这些 mod 无法在 Adyeshach 单位上渲染模型（例如经 Orryx 的 DragonCore 桥套模型时只显示原始实体）。

## 改动

新增配置项 `Settings.negative-entity-id`：

- 默认 `true`，**保持现状、完全向后兼容**（负数 ID）。
- 设为 `false` 时改用**正数** ID，基数自动抬到 `1_500_000_000`，以尽量避免与服务端真实实体 ID（从低位递增）冲突。

涉及 3 个文件：
- `core/config.yml`：新增带注释的配置项
- `AdyeshachSettings.kt`：新增 `negativeEntityId` 绑定
- `Indexs.kt`：基数与正负号按配置决定（初始化时缓存，保证同一会话内一致）

## 测试

- 环境：Paper 1.12.2 + Orryx 2.39.103 + DragonCore 2.6.2.9（客户端 mod 1.0.0）
- 设为 `false` 后，Adyeshach 单位经 DragonCore 正常渲染模型（此前只显示盔甲架）
- `:project:common` 与 `:project:common-impl` 编译通过

Closes #119
