### PR TITLE
增加玩家与单位的交互冷却

### DIFF
--- a/project/common-impl/src/main/kotlin/ink/ptms/adyeshach/impl/manager/EntityInteractCooldown.kt
+++ b/project/common-impl/src/main/kotlin/ink/ptms/adyeshach/impl/manager/EntityInteractCooldown.kt
@@ -1,0 +1,45 @@
+package ink.ptms.adyeshach.impl.manager
+
+import ink.ptms.adyeshach.core.AdyeshachSettings
+import ink.ptms.adyeshach.core.event.AdyeshachEntityDamageEvent
+import ink.ptms.adyeshach.core.event.AdyeshachEntityInteractEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import taboolib.common.platform.event.EventPriority
+import taboolib.common.platform.event.SubscribeEvent
+
+/**
+ * 玩家与虚拟单位的交互冷却
+ * 在 TraitCommand 等 MONITOR 监听之前取消事件，左键、右键共用，按玩家计算。
+ */
+internal object EntityInteractCooldown {
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    private fun onInteract(e: AdyeshachEntityInteractEvent) {
+        if (!e.isMainHand) {
+            return
+        }
+        if (!tryAcquire(e.player.name)) {
+            e.isCancelled = true
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    private fun onDamage(e: AdyeshachEntityDamageEvent) {
+        if (!tryAcquire(e.player.name)) {
+            e.isCancelled = true
+        }
+    }
+
+    @SubscribeEvent
+    private fun onQuit(e: PlayerQuitEvent) {
+        AdyeshachSettings.interactCooldownBaffle?.reset(e.player.name)
+    }
+
+    /**
+     * @return true 允许本次交互
+     */
+    private fun tryAcquire(id: String): Boolean {
+        val baffle = AdyeshachSettings.interactCooldownBaffle ?: return true
+        return baffle.hasNext(id)
+    }
+}

--- a/project/common/src/main/kotlin/ink/ptms/adyeshach/core/AdyeshachSettings.kt
+++ b/project/common/src/main/kotlin/ink/ptms/adyeshach/core/AdyeshachSettings.kt
@@ -4,10 +4,12 @@ import taboolib.common.LifeCycle
 import taboolib.common.platform.Awake
 import taboolib.common.platform.function.getDataFolder
 import taboolib.common.util.resettableLazy
+import taboolib.common5.Baffle
 import taboolib.module.configuration.Config
 import taboolib.module.configuration.ConfigNode
 import taboolib.module.configuration.Configuration
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 /**
  * Adyeshach
@@ -39,7 +41,8 @@ object AdyeshachSettings {
     var debug = false
 
     /**
-     * 单位可视距离
+     * 单位可视半径（格）。进入后发包生成，离开后回收。
+     * 建议小于 server.properties 的 view-distance × 16。
      */
     @ConfigNode("Settings.visible-distance")
     var visibleDistance = 64.0
@@ -102,6 +105,21 @@ object AdyeshachSettings {
      */
     @ConfigNode("Settings.negative-entity-id")
     var negativeEntityId = false
+
+    /**
+     * 玩家与单位的交互冷却（毫秒）
+     * 0 表示关闭
+     */
+    @ConfigNode("Settings.interact-cooldown")
+    var interactCooldown = 1000
+
+    /**
+     * 交互冷却闸门，reload 后重建
+     */
+    val interactCooldownBaffle by resettableLazy {
+        val time = interactCooldown.toLong()
+        if (time <= 0L) null else Baffle.of(time, TimeUnit.MILLISECONDS)
+    }
 
     /**
      * 是否为自动删除世界

--- a/project/common/src/main/resources/core/config.yml
+++ b/project/common/src/main/resources/core/config.yml
@@ -5,7 +5,9 @@
 
 Settings:
   debug: false
-  # 必须小于 server.properties 中的 "view-distance"
+  # 玩家与单位的可视半径，单位是格（不是区块）
+  # 进入范围才发包生成，离开后回收；默认 64 格 ≈ 4 个区块
+  # 建议小于 server.properties 的 view-distance × 16（视距 8 区块 ≈ 128 格）
   visible-distance: 64
   # JOIN: 当玩家加入服务器时
   # KEEP_ALIVE: 当玩家发送第一个位置数据包时
@@ -34,3 +36,6 @@ Settings:
   # 是否使用负数虚拟实体 ID
   # 默认关闭，保留正数 ID
   negative-entity-id: false
+  # 玩家与单位的交互冷却（毫秒）
+  # 左键、右键共用，按玩家计算；0 表示关闭
+  interact-cooldown: 1000


### PR DESCRIPTION
玩家快速连点 NPC 时，TraitCommand 绑定的命令会被连续触发，所以加了一个可配置的交互冷却。

新增 Settings.interact-cooldown（毫秒），左右键共用、按玩家计算，0 为关闭。事件监听放在 LOWEST，在 TraitCommand 等 MONITOR 监听之前就把过快的交互取消。顺带补充了 visible-distance 的注释，说明单位是格。

已在 1.12.2 服务端测试过，交互冷却没有问题。

另外可以考虑要不要在冷却未结束时给玩家一条文字提示。
